### PR TITLE
Change userScore subscription

### DIFF
--- a/src/components/UserScore.js
+++ b/src/components/UserScore.js
@@ -1,11 +1,12 @@
+//react+redux
 import React,{Component} from 'react'
 import {connect} from 'react-redux'
 import PropTypes from 'prop-types'
-
+//gql
 import {graphql} from 'react-apollo'
 import {USER_SCORECARD_QUERY} from '../gql/Scorecard/queries'
-import {UPDATE_USER_SCORECARD_SUBSCRIPTION} from '../gql/Scorecard/subscriptions'
-
+import {USER_SCORE_CREATED_SUBSCRIPTION} from '../gql/Score/subscriptions'
+//other
 import {muiColors} from '../lib/theme/colors'
 
 class UserScore extends Component {
@@ -41,15 +42,18 @@ const UserScoreWithData = graphql(USER_SCORECARD_QUERY,{
       data,
       subscribeToScorecardUpdates: () => {
         return data.subscribeToMore({
-          document: UPDATE_USER_SCORECARD_SUBSCRIPTION,
+          document: USER_SCORE_CREATED_SUBSCRIPTION,
           variables: {id: ownProps.apiUserScorecardId},
           updateQuery: (prev, {subscriptionData}) => {
             if (!subscriptionData.data) {
-                return prev;
+                return prev
             }
-            const newFeedItem = subscriptionData.data.Scorecard.node
+            const newScoreValue = subscriptionData.data.Score.node.value
+            const newScorecardTotal = prev.Scorecard.total + newScoreValue
+            const newScorecard = {...prev.Scorecard}
+            newScorecard.total = newScorecardTotal
             return {
-                Scorecard: newFeedItem,
+                Scorecard: newScorecard,
             }
           }
         })

--- a/src/gql/Score/subscriptions.js
+++ b/src/gql/Score/subscriptions.js
@@ -3,7 +3,20 @@ import {gql} from 'react-apollo'
 export const SCORE_CREATED_SUBSCRIPTION = gql`
   subscription ScoreCreatedSubscription{
     Score(filter:{mutation_in:[CREATED]}){
-    	mutation
+      node{
+        value
+      }
+    }
+  }
+`
+export const USER_SCORE_CREATED_SUBSCRIPTION = gql`
+  subscription userScoreCreatedSubscription($userScorecardId:ID){
+    Score(filter:{
+      mutation_in:[CREATED],
+      node:{
+        scorecard:{id:$userScorecardId}
+      }
+    }){
       node{
         value
       }


### PR DESCRIPTION
## Changes:
### userScorecard total subscription changed.
1.  The total is updating based on new scores subscription not scorecard updates subscription because scorecard subscriptions introduced a 2-3 second delay ( User scorecards are updated by calling a serverless function (that takes 1-3 seconds to complete) in response to a score created SSS. 
## Implications:
1. It is possible for the score in the client to be higher than the user `Scorercard.total` in the db, this is because incrementing of the score is imperfect, if 2 score are created for the same user within 3-4 seconds of each other it is possible to only update the score once. This is a limitation of `graphcool`. It may be better to determine score the same way that it is done for community score. 