### PR TITLE
Fullscreen views Prototype

### DIFF
--- a/src/actions/layout-actions.js
+++ b/src/actions/layout-actions.js
@@ -1,0 +1,10 @@
+import * as ActionTypes from './types'
+
+export const hideScreen = (html) => ({
+  type: ActionTypes.HIDE_SCREEN,
+  html
+})
+
+export const showScreen = () => ({
+  type: ActionTypes.SHOW_SCREEN,
+})

--- a/src/actions/layout-actions.js
+++ b/src/actions/layout-actions.js
@@ -1,8 +1,7 @@
 import * as ActionTypes from './types'
 
-export const hideScreen = (html) => ({
+export const hideScreen = () => ({
   type: ActionTypes.HIDE_SCREEN,
-  html
 })
 
 export const showScreen = () => ({

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -21,3 +21,6 @@ export const INITIAL_COMMUNITY_SCORE = 'INITIAL_COMMUNITY_SCORE'
 // Editor
 export const EDITOR_CHANGE = 'EDITOR_CHANGE'
 export const CLEAR_EDITOR = 'CLEAR_EDITOR'
+// layout
+export const  HIDE_SCREEN = 'HIDE_SCREEN'
+export const  SHOW_SCREEN = 'SHOW_SCREEN'

--- a/src/components/ChallengeCard.js
+++ b/src/components/ChallengeCard.js
@@ -8,6 +8,7 @@ import {
   showUpdateChallengeView,
   showChallengeDetailView,
 } from '../actions/challenge-actions'
+import {hideScreen} from '../actions/layout-actions'
 //gql
 import {compose,graphql} from 'react-apollo'
 import {
@@ -154,6 +155,11 @@ class ChallengeCard extends Component {
       )
   }
 
+  showDetail = () => {
+    this.props.hideScreen()
+    this.props.showChallengeDetailView(this.props.id)
+  }
+
   render(){
     const {title, description, id, userDidUpvote} = this.props.challenge
     const upvotesCount = this.props.challenge._upvotesMeta.count
@@ -198,7 +204,7 @@ class ChallengeCard extends Component {
               <Update/>
             </IconButton>
             <FlatButton
-              onTouchTap={()=> showChallengeDetailView(id)}
+              onTouchTap={this.showDetail}
               label="Show"
               primary={true}
             />
@@ -219,6 +225,7 @@ const mapDispatchToProps = (dispatch) => {
     showUpdateChallengeView,
     hideUpdateChallengeView,
     showChallengeDetailView,
+    hideScreen,
   }, dispatch)
 }
 

--- a/src/components/Site.js
+++ b/src/components/Site.js
@@ -10,6 +10,7 @@ import SyncUser from './SyncUser'
 import BottomBar from './BottomBar'
 import Navbar from './navbar/Navbar'
 import Scoreboard from './scoreboard/Scoreboard'
+import TestScroll from './TestScroll'
 import '../styles/css/layout.css'
 import {
   HEADER_Z_INDEX,
@@ -59,6 +60,9 @@ class Site extends Component {
       }
 
     const styles = {
+      app:{
+
+      },
       headroom: {
         zIndex: HEADER_Z_INDEX
       },
@@ -74,10 +78,29 @@ class Site extends Component {
         flexDirection: 'column',
       //<---
         backgroundColor:"#f6f0f0",
+        zIndex: this.props.isScreenVisible ? '1' : '1'
       },
+      fullscreen:{
+        display: 'flex',
+        minHeight: '100vh',
+        flexDirection: 'column',
+        position: 'fixed',
+        top: 0,
+      //<---
+        backgroundColor:"#f6f0f0",
+        zIndex: 2000,
+
+      }
+    }
+
+    const renderChallengeDetail = () =>{
+      if(!this.props.isScreenVisible && this.props.openChallengeDetailViewId ){
+        return(<TestScroll/>)
+      }
     }
 
     return(
+    <div>
       <div style={styles.main}>
       {/* component that syncs or creates a user depending on redux state: */}
       { this.shouldSyncUser() && renderSyncUser() }
@@ -103,6 +126,12 @@ class Site extends Component {
           <BottomBar/>
         </div>
       </div>
+      <div style={styles.fullscreen}>
+        { renderChallengeDetail() }
+        {!this.props.isScreenVisible && <TestScroll/>}
+      </div>
+    </div>
+
     )
   }
 }
@@ -112,6 +141,8 @@ const mapStateToProps = (state) => {
     auth0Authenticated: state.app.auth.auth0Authenticated,
     userSynced: state.app.auth.userSynced,
     profile: state.app.auth.profile,
+    openChallengeDetailViewId: state.app.challenges.openChallengeDetailViewId,
+    isScreenVisible: state.app.layout.isScreenVisible,
   }
 }
 

--- a/src/components/TestScroll.js
+++ b/src/components/TestScroll.js
@@ -1,0 +1,45 @@
+import React, {Component} from 'react'
+import styled from 'styled-components'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+import {showScreen} from '../actions/layout-actions'
+
+const DivTing = styled.div`
+  height: 200px;
+  width: 800px;
+  background-color: rgb(95, 222, 139);
+  margin-bottom: 20px;
+`
+
+class TestScroll extends Component{
+  render(){
+    return(
+      <div>
+        <button onClick={()=> this.props.showScreen()}>Close</button>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+        <DivTing/>
+      </div>
+    )
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return bindActionCreators({
+      showScreen
+    }, dispatch)
+}
+
+export default connect(null,mapDispatchToProps)(TestScroll)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,12 +3,14 @@ import auth from './auth-reducer'
 import challenges from './challenges-reducer'
 import scores from './score-reducer'
 import editor from './editor-reducer'
+import layout from './layout-reducer'
 
 const appRootReducer = combineReducers({
   auth,
   challenges,
   scores,
   editor,
+  layout,
 })
 
 export default appRootReducer

--- a/src/reducers/layout-reducer.js
+++ b/src/reducers/layout-reducer.js
@@ -1,0 +1,14 @@
+import * as ActionTypes from '../actions/types'
+
+const initialState = {isScreenVisible: true, }
+
+export default function layoutReducer(state=initialState, action) {
+  switch (action.type) {
+    case ActionTypes.HIDE_SCREEN:
+      return {...state, isScreenVisible: false}
+    case ActionTypes.SHOW_SCREEN:
+      return {...state, isScreenVisible: true}
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
Alternative to fullscreen modal.
- Works like 💩 
- Idea is to hide the main app component (including top and bottom bars) and render a fullscreen view over it. 
- tried visibility css property but leaves space, display 'none' does not preserve scroll, negative ZIndex causes too many clashes with other elements.

