### PR TITLE
Improve Editor UX 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/react-quill@1.0.0-rc.2/dist/quill.snow.css">
+    <link rel="stylesheet" href="https://unpkg.com/react-quill@1.0.0/dist/quill.bubble.css">
     <script src="https://use.fontawesome.com/7592f9ae31.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.

--- a/src/components/ChallengeList.js
+++ b/src/components/ChallengeList.js
@@ -24,6 +24,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import MaterialDialog from './MaterialDialog'
 import GenericError from './commons/GenericError'
 import Editor from './Editor'
+import Dialog from 'components/Dialog'
 
 class ChallengeList extends Component {
   //so can change query variables in one place and pass to child components:
@@ -111,15 +112,22 @@ class ChallengeList extends Component {
             mdOffset={3} md={6}
             lgOffset={3} lg={6}
           >
-            <MaterialDialog
+            {/* <MaterialDialog
               isOpen={this.props.isCreateViewOpen}
               handleClose={this.props.hideCreateChallengeView}
-              title='Create A Challenge'
+
               repositionOnUpdate={false}
               modal={true}
             >
               {createChallengeForm}
-            </MaterialDialog>
+            </MaterialDialog> */}
+            <Dialog
+              isOpen={this.props.isCreateViewOpen}
+              handleClose={this.props.hideCreateChallengeView}
+              title='Create A Challenge'
+            >
+              {createChallengeForm}
+            </Dialog>
             <Row>
             {challengeCards}
             </Row>

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -49,6 +49,8 @@ const ExitBox = styled.div`
 `
 const ChildrenContainer = styled.div`
   padding-bottom: 5vh;
+  display: flex;
+  justify-content: center;
 `
 //Wrapper component for react modal:
 export default class Dialog extends Component {


### PR DESCRIPTION
## Before
- Material UI modal doesn't go full screen + editor jumps around.
- Easy to skip title/ description input and not see the error message. 
- Tried switching to bubble editor but didn't work well on mobile and cuts off at beginning of input box.

## Changes 
1. Move to custom modal component 
2. Create custom input instead of material form. 

