### PR TITLE
Change Score System

### DIFF
--- a/src/components/scoreboard/CommunityScore.js
+++ b/src/components/scoreboard/CommunityScore.js
@@ -13,6 +13,7 @@ import {levels} from '../../gql/Score/score-system'
 import {COMMUNITY_SCORE_COUNTS_QUERY} from '../../gql/Score/queries'
 import {SCORE_CREATED_SUBSCRIPTION} from '../../gql/Score/subscriptions'
 //other
+import {logException} from 'config'
 
 class CommunityScore extends Component {
   static propTypes = {
@@ -53,8 +54,16 @@ class CommunityScore extends Component {
   }
 
   render(){
-    if (this.props.data.loading || !this.props.communityScore){
+    const {data} = this.props
+
+    if (data.loading ){
       return(<h2>loading...</h2>)
+    }
+    if (data.error){
+      logException(data.error, {
+      action: "CommunityScore query in CommunityScore.js"
+      })
+      return <p>error</p>
     }
     return(
       <span style={this.props.style}>

--- a/src/components/scoreboard/UserScore.js
+++ b/src/components/scoreboard/UserScore.js
@@ -21,10 +21,11 @@ class UserScore extends Component {
    }
 
   render(){
-    if (this.props.data.loading){
+    const {data} = this.props
+    if (data.loading){
       return(<h2>loading...</h2>)
     }
-    if (this.props.data.error){
+    if (data.error){
       logException(this.props.data.error, {
       action: "UserScore query in UserScore.js"
       })

--- a/src/gql/Score/score-system.js
+++ b/src/gql/Score/score-system.js
@@ -1,27 +1,37 @@
 
-// score values should always be defined in z-index.js
-// allows us to change score values of each action in one place and prevents bugs
-// arising from inconsistent value. Do not edit existing entries in the levels
-// system, only add new entries if necessary
+/*
+ score values should always be defined in z-index.js
+ allows us to change score values of each action in one place and prevents bugs
+ arising from inconsistent value. Do not edit existing entries in the levels
+ system, only add new entries if necessary
 
+ Score value system:
+ name attribute used in community Aggregate query to determine total
+ temporary solution until able to increment community aggregate score
+ on the server
+ --------------------------------------------------
+ Make sure not all numbers are ending with 0s (i.e 50,100,150) because
+ last number of the score total will never change (always 0).
+ It looks more intesting to have all digits of a number changing.
+*/
 
-// Score value system:
-// name attribute used in community Aggregate query to determine total
-// temporary solution until able to increment community aggregate score
-// on the server
-// --------------------------------------------------
 export const levels = {
-  one: {value: 50, name: 'fifty'},
-  two: {value: 100, name: 'hundred'},
-  three: {value: 150, name: 'hundredfifty' },
+  //names cannot include numbers to use in query,
+  one: {value: 55, name: 'fiftyfive'},
+  //Haven't used these yet:
+  two: {value: 105, name: 'hundredandfive'},
+  three: {value: 200, name: 'twohundred' },
 }
 
-// Score system Applications
-//Allows for dynamic community total queries using the name attribute
-//of each score level
-// Accessing values for mutations:
-// APPLICATION_NAME.value  i.e) CHALLENGE_CREATE_SCORE.value
-//Accessing name for queries: APPLICATION_NAME.name
-// --------------------------------------------------
+/*
+  Score system Applications
+  Allows for dynamic community total queries using the name attribute
+  of each score level
+  Accessing values for mutations:
+  APPLICATION_NAME.value  i.e) CHALLENGE_CREATE_SCORE.value
+  Accessing name for queries: APPLICATION_NAME.name
+  --------------------------------------------------
+*/
+
 
 export const CHALLENGE_CREATE_SCORE = levels.one


### PR DESCRIPTION
Old score system moved up by factors of 10 therefore the last digit of the total would always be 0 making score changes less noticeable. Changed score system so that have movement in the last digit. 
## Changes:
1. Changed score values/names
2. Added error logging to Community score