### PR TITLE
Fix user score

### DIFF
--- a/src/actions/score-actions.js
+++ b/src/actions/score-actions.js
@@ -9,3 +9,13 @@ export const updateCommunityScore = (value, scoreId) => ({
   value,
   scoreId
 })
+
+export const initializeUserScore = (value) => ({
+  type: ActionTypes.INITIAL_USER_SCORE,
+  value
+})
+export const updateUserScore = (value, scoreId) => ({
+  type: ActionTypes.NEW_USER_SCORE,
+  value,
+  scoreId
+})

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -23,6 +23,9 @@ export const CHALLENGE_CREATED = 'CHALLENGE_CREATED'
 export const NEW_COMMUNITY_SCORE = 'NEW_COMMUNITY_SCORE'
 export const INITIAL_COMMUNITY_SCORE = 'INITIAL_COMMUNITY_SCORE'
 
+export const NEW_USER_SCORE = 'NEW_USER_SCORE'
+export const INITIAL_USER_SCORE = 'INITIAL_USER_SCORE'
+
 /*------------------- Editor ------------------------*/
 export const EDITOR_CHANGE = 'EDITOR_CHANGE'
 export const CLEAR_EDITOR = 'CLEAR_EDITOR'

--- a/src/components/scoreboard/CommunityScore.js
+++ b/src/components/scoreboard/CommunityScore.js
@@ -60,9 +60,9 @@ class CommunityScore extends Component {
     const level3Value = levels.three.value
 
     const CommunityTotal = (
-      level1Count*level1Value +
-      level2Count*level2Value +
-      level3Count*level3Value
+      level1Count * level1Value +
+      level2Count * level2Value +
+      level3Count * level3Value
     )
     return(CommunityTotal)
   }
@@ -72,7 +72,7 @@ class CommunityScore extends Component {
   }
 
   render(){
-    const {data, animation1, animation2} = this.props
+    const {data, communityAnimation1, communityAnimation2} = this.props
 
     if (data.loading ){
       return(<div></div>)
@@ -86,8 +86,8 @@ class CommunityScore extends Component {
     //make sure score remounts on prop change so animation plays:
     return(
       <div>
-        {animation1 && this.renderScore()}
-        {animation2 && this.renderScore()}
+        {communityAnimation1 && this.renderScore()}
+        {communityAnimation2 && this.renderScore()}
       </div>
     )
   }
@@ -105,13 +105,14 @@ const CommunityScoreWithData = graphql(COMMUNITY_SCORE_COUNTS_QUERY,{
         return data.subscribeToMore({
           document: SCORE_CREATED_SUBSCRIPTION,
           updateQuery: (prev, {subscriptionData}) => {
-            //get console errors for missing fields since this is a different query
             if (!subscriptionData.data) {
-                return prev;
+                return prev
             }
             const {value, id} = subscriptionData.data.Score.node
             ownProps.updateCommunityScore(value, id)
             return {
+                /* don't update apollo store using redux app store for
+                scores */
                 prev,
             }
           }
@@ -125,8 +126,8 @@ const CommunityScoreWithData = graphql(COMMUNITY_SCORE_COUNTS_QUERY,{
 const mapStateToProps = (state) => {
   return {
     communityScore: state.app.scores.communityScore,
-    animation1: state.app.scores.animation1,
-    animation2: state.app.scores.animation2,
+    communityAnimation1: state.app.scores.communityAnimation1,
+    communityAnimation2: state.app.scores.communityAnimation2,
   }
 }
 

--- a/src/components/scoreboard/UserScore.js
+++ b/src/components/scoreboard/UserScore.js
@@ -91,10 +91,8 @@ const UserScoreWithData = graphql(USER_SCORECARD_QUERY,{
             if (!subscriptionData.data) {
                 return prev
             }
-            const {node} = subscriptionData.data.Score.node
-            const {value,id} = node
-            const scorecardId = node.scorecard.id
-            
+            const {value,id} = subscriptionData.data.Score.node
+            const scorecardId = subscriptionData.data.Score.node.scorecard.id
             /* even though filtering subscriptions by scorecard id, receiveing
             events that belong to other scorecards, correcting for this: */
             if (ownProps.scorecardId === scorecardId){

--- a/src/gql/Score/subscriptions.js
+++ b/src/gql/Score/subscriptions.js
@@ -21,6 +21,9 @@ export const USER_SCORE_CREATED_SUBSCRIPTION = gql`
       node{
         id
         value
+        scorecard{
+          id
+        }
       }
     }
   }

--- a/src/reducers/score-reducer.js
+++ b/src/reducers/score-reducer.js
@@ -1,19 +1,44 @@
 import * as ActionTypes from '../actions/types'
 
-const initialState = {communityScore: null, scoreEventId:'' ,animation1: true, animation2: false}
+const initialState = {
+  communityScore: null,
+  communityScoreEventId:'',
+  communityAnimation1: true,
+  communityAnimation2: false,
+  userScore: '',
+  userScoreEventId:'',
+  userAnimation1: true,
+  userAnimation2: false,
+}
 
 const updateCommunityScore = (state, action) => {
   // protect from duplicate events causing score to be our of sync with server:
-  if (state.scoreEventId === action.scoreId){
+  if (state.communityScoreEventId === action.scoreId){
     return state.communityScore
   }
-  else if (state.scoreEventId !== action.scoreId) {
+  else if (state.communityScoreEventId !== action.scoreId) {
     return({
       // animation hack - switching between 2 animation states acts as a reset :
-      animation1: !state.animation1,
-      animation2: !state.animation2,
-      scoreEventId: action.scoreId,
+      communityAnimation1: !state.communityAnimation1,
+      communityAnimation2: !state.communityAnimation2,
+      communityScoreEventId: action.scoreId,
       communityScore: state.communityScore + action.value,
+    })
+  }
+}
+
+const updateUserScore = (state, action) => {
+  // protect from duplicate events causing score to be our of sync with server:
+  if (state.userScoreEventId === action.scoreId){
+    return state.userScore
+  }
+  else if (state.userScoreEventId !== action.scoreId) {
+    return({
+      // animation hack - switching between 2 animation states acts as a reset :
+      userAnimation1: !state.userAnimation1,
+      userAnimation2: !state.userAnimation2,
+      userScoreEventId: action.scoreId,
+      userScore: state.userScore + action.value,
     })
   }
 }
@@ -23,11 +48,19 @@ export default function scoreReducer(state=initialState, action) {
     case ActionTypes.INITIAL_COMMUNITY_SCORE:
       return {...state, communityScore: action.value}
     case ActionTypes.NEW_COMMUNITY_SCORE:
-      const updatedState = updateCommunityScore(state, action)
+      const updatedCommunityState = updateCommunityScore(state, action)
       return {
         ...state,
-        ...updatedState
+        ...updatedCommunityState
       }
+    case ActionTypes.INITIAL_USER_SCORE:
+      return {...state, userScore: action.value}
+    case ActionTypes.NEW_USER_SCORE:
+      const updatedUserState = updateUserScore(state, action)
+      return {
+        ...state,
+        ...updatedUserState
+    }
     default:
       return state
   }


### PR DESCRIPTION
## Changes
1. handle duplicate events using redux.
2. only update score for current user.

** This subscription is unreliable, so may be better to refetch the query after every score create.