### PR TITLE
Composite feed prototype

### DIFF
--- a/src/components/ChallengeList.js
+++ b/src/components/ChallengeList.js
@@ -17,6 +17,16 @@ export default class ChallengeList extends Component {
 
   state={scrollTop:false}
 
+  feedify = (...lists) => {
+    const listLengths = lists.map(list => list.length)
+    const longestListLength = Math.max(...listLengths)
+    const newArr = []
+    for (let i = 0; i < longestListLength; i++){
+      lists.forEach(list => list[i] && newArr.push(list[i]))
+    };
+  return newArr
+}
+
   renderChallengeCards = () => {
 
     const {
@@ -39,10 +49,22 @@ export default class ChallengeList extends Component {
     )
   }
 
+  mapTaskList = () => {
+    const {tasks} = this.props
+    return tasks.map(task => <div
+        style={{backgroundColor:'rgb(139, 236, 199)'}}
+        key={'task'+task.id}
+        >
+        {task.type}
+      </div>
+    )
+  }
 
   render(){
     const {hasMore, loadMoreEntries} = this.props
-
+    const challengeList = this.renderChallengeCards()
+    const taskList = this.mapTaskList()
+    const feed = this.feedify(challengeList, taskList)
     /* ---------------- render return -----------------*/
 
     return(
@@ -53,7 +75,8 @@ export default class ChallengeList extends Component {
         next={loadMoreEntries}
        >
          {this.state.scrollTop && window.scrollTo(0,0)}
-        {this.renderChallengeCards()}
+        {/* {this.renderChallengeCards()} */}
+        {feed}
       </InfiniteScroll>
     )
   }

--- a/src/components/ChallengeList.js
+++ b/src/components/ChallengeList.js
@@ -1,6 +1,8 @@
 // React
 import React,{Component} from 'react'
 import PropTypes from 'prop-types'
+// helpers + other
+import {normalizeToFeed} from 'lib/array-helpers'
 //components
 import ChallengeCard from './ChallengeCard'
 import InfiniteScroll from 'react-infinite-scroll-component'
@@ -64,7 +66,7 @@ export default class ChallengeList extends Component {
     const {hasMore, loadMoreEntries} = this.props
     const challengeList = this.renderChallengeCards()
     const taskList = this.mapTaskList()
-    const feed = this.feedify(challengeList, taskList)
+    const feed = normalizeToFeed(challengeList, taskList)
     /* ---------------- render return -----------------*/
 
     return(

--- a/src/components/ChallengeList.js
+++ b/src/components/ChallengeList.js
@@ -7,6 +7,7 @@ import {normalizeToFeed} from 'lib/array-helpers'
 import ChallengeCard from './ChallengeCard'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import GenericLoader from 'ui-kit/GenericLoader'
+import {Card} from 'ui-kit'
 
 export default class ChallengeList extends Component {
   static propTypes = {
@@ -62,10 +63,27 @@ export default class ChallengeList extends Component {
     )
   }
 
+  renderTaskCards = () => {
+  const {tasks} = this.props
+    return tasks.map(task => {
+      if (task.type === 'Discussion'){
+        return(
+            <Card
+              key={'tasklist'+task.id}
+              text={task.discussion.topic}
+              onBodyClick={()=>{alert('clicked:'+task.id)}}
+            />
+          )
+        }
+        else return ''
+      }
+    )
+  }
+
   render(){
     const {hasMore, loadMoreEntries} = this.props
     const challengeList = this.renderChallengeCards()
-    const taskList = this.mapTaskList()
+    const taskList = this.renderTaskCards()
     const feed = normalizeToFeed(challengeList, taskList)
     /* ---------------- render return -----------------*/
 
@@ -76,7 +94,7 @@ export default class ChallengeList extends Component {
         loader={<GenericLoader text="..."/>}
         next={loadMoreEntries}
        >
-         {this.state.scrollTop && window.scrollTo(0,0)}
+        {this.state.scrollTop && window.scrollTo(0,0)}
         {/* {this.renderChallengeCards()} */}
         {feed}
       </InfiniteScroll>

--- a/src/components/ChallengeListContainer.js
+++ b/src/components/ChallengeListContainer.js
@@ -2,11 +2,13 @@
 import React,{Component} from 'react'
 import {connect} from 'react-redux'
 //gql
-import {graphql} from 'react-apollo'
+import {compose,graphql} from 'react-apollo'
 import {
   ALL_CHALLENGES_QUERY,
   MORE_CHALLENGES_QUERY,
+  ALL_CHALLENGES,
 } from '../gql/Challenge/queries'
+import {ALL_TASKS_QUERY} from '../gql/Task/queries'
 //helpers+other
 import {uniqBy} from 'lodash'
 import {logException} from '../config'
@@ -20,76 +22,87 @@ class ChallengeListContainer extends Component {
     //so can change query variables in one place and pass to child components:
     const allChallengesQueryVariables = {"filter":{ "id": this.props.apiUserId}}
 
-    if (this.props.loading){
+    if (this.props.allChallengesQuery.loading || this.props.allTasksQuery.loading){
       return <GenericLoader text="loading..." />
     }
 
-    if(this.props.error){
-      logException(this.props.error, {action: 'query in ChallengeListContainer'})
-      return <GenericError />
-    }
+    // if(this.props.error){
+    //   logException(this.props.error, {action: 'query in ChallengeListContainer'})
+    //   return <GenericError />
+    // }
+
+    const {allChallengesQuery, allTasksQuery} = this.props
 
     return(
         <ChallengeList
-          challenges={this.props.allChallenges}
+          challenges={allChallengesQuery.allChallenges}
           allChallengesQueryVariables={allChallengesQueryVariables}
           apiUserId={this.props.apiUserId}
-          hasMore={this.props.cursor.length === 0 ? false : true}
-          loadMoreEntries={()=>this.props.loadMoreEntries()}
+          hasMore={allChallengesQuery.cursor.length === 0 ? false : true}
+          loadMoreEntries={()=>allChallengesQuery.loadMoreEntries()}
+          tasks = {allTasksQuery.allTasks}
         />
       )
     }
   }
 
-const ChallengeListApollo = graphql(
-    ALL_CHALLENGES_QUERY, {
-      props: ({
-        ownProps,
-        data: { loading, error, allChallenges, cursor, fetchMore},
-      }) => {
-        return ({
-          error,
-          loading,
-          allChallenges,
-          cursor,
-          loadMoreEntries: () => {
-            return fetchMore({
-              query: MORE_CHALLENGES_QUERY,
-              variables: {
-                filter:{
-                  id: ownProps.apiUserId ? ownProps.apiUserId : '',
-                },
-                cursor: cursor[0].id,
-                querySize: 3,
+const allChallengesQueryOptions = {
+  props: ({
+    ownProps,
+    data: { loading, error, allChallenges, cursor, fetchMore},
+  }) => {
+    return ({
+      allChallengesQuery:{
+        error,
+        loading,
+        allChallenges,
+        cursor,
+        loadMoreEntries: () => {
+          return fetchMore({
+            query: MORE_CHALLENGES_QUERY,
+            variables: {
+              filter:{
+                id: ownProps.apiUserId ? ownProps.apiUserId : '',
               },
-              updateQuery: ( previousResult, { fetchMoreResult }) => {
-                const previousChallenges = previousResult.allChallenges
-                const newChallenges = fetchMoreResult.allChallenges
-                //prevents adding duplicate when query overlaps with previously
-                // manually added entry in apollo cache ( using update).
-                const allChallenges = uniqBy(
-                  [...previousChallenges, ...newChallenges],
-                  'id'
-                )
-                return {
-                  allChallenges,
-                  cursor: fetchMoreResult.cursor
-                }
-              },
-            })
-          },
-        })},
-    //query:
-      options: (ownProps)=>({
-        variables: {
-          filter:{
-            id: ownProps.apiUserId ? ownProps.apiUserId : '',
-          },
+              cursor: cursor[0].id,
+            },
+            updateQuery: ( previousResult, { fetchMoreResult }) => {
+              const previousChallenges = previousResult.allChallenges
+              const newChallenges = fetchMoreResult.allChallenges
+              //prevents adding duplicate when query overlaps with previously
+              // manually added entry in apollo cache ( using update).
+              const allChallenges = uniqBy(
+                [...previousChallenges, ...newChallenges],
+                'id'
+              )
+              return {
+                allChallenges,
+                cursor: fetchMoreResult.cursor
+              }
+            },
+          })
         },
-        fetchPolicy: 'network-only',
-      }),
+      }
+    })},
+//query:
+  options: (ownProps)=>({
+    variables: {
+      filter:{
+        id: ownProps.apiUserId ? ownProps.apiUserId : '',
+      },
     },
-  )(ChallengeListContainer)
+    fetchPolicy: 'network-only',
+    name: "allChallenges"
+  }),
+}
+
+const ChallengeListApollo = compose(
+  graphql(ALL_CHALLENGES_QUERY, allChallengesQueryOptions),
+
+  graphql(ALL_TASKS_QUERY, {name: 'allTasksQuery'}),
+  // graphql(ALL_CHALLENGES, {name: 'allChallengesQuery'}),
+
+)(ChallengeListContainer)
 
 const mapStateToProps = (state) => {
   return {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -12,7 +12,7 @@ import {
 import {requireAuth} from '../lib/auth'
 import styled from 'styled-components'
 //Components
-import ChallengeListContainer from './ChallengeListContainer'
+import HomeFeedContainer from './HomeFeedContainer'
 import ChallengeDetailContainer from './ChallengeDetailContainer'
 import ChallengeFormContainer from 'components/ChallengeFormContainer'
 import Dialog from 'ui-kit/Dialog'
@@ -83,7 +83,7 @@ class Home extends Component {
 
     const centerContent = (
       <ChallengeListBox>
-        <ChallengeListContainer />
+        <HomeFeedContainer />
       </ChallengeListBox>
     )
 

--- a/src/components/HomeFeedContainer.js
+++ b/src/components/HomeFeedContainer.js
@@ -17,7 +17,7 @@ import ChallengeList from 'components/ChallengeList'
 import GenericError from 'ui-kit/GenericError'
 import GenericLoader from 'ui-kit/GenericLoader'
 
-class ChallengeListContainer extends Component {
+class HomeFeedContainer extends Component {
   render(){
     //so can change query variables in one place and pass to child components:
     const allChallengesQueryVariables = {"filter":{ "id": this.props.apiUserId}}
@@ -40,7 +40,7 @@ class ChallengeListContainer extends Component {
           apiUserId={this.props.apiUserId}
           hasMore={allChallengesQuery.cursor.length === 0 ? false : true}
           loadMoreEntries={()=>allChallengesQuery.loadMoreEntries()}
-          tasks = {allTasksQuery.allTasks}
+          tasks={allTasksQuery.allTasks}
         />
       )
     }
@@ -96,13 +96,13 @@ const allChallengesQueryOptions = {
   }),
 }
 
-const ChallengeListApollo = compose(
+const HomeFeedContainerApollo = compose(
   graphql(ALL_CHALLENGES_QUERY, allChallengesQueryOptions),
 
   graphql(ALL_TASKS_QUERY, {name: 'allTasksQuery'}),
   // graphql(ALL_CHALLENGES, {name: 'allChallengesQuery'}),
 
-)(ChallengeListContainer)
+)(HomeFeedContainer)
 
 const mapStateToProps = (state) => {
   return {
@@ -111,4 +111,4 @@ const mapStateToProps = (state) => {
   }
 }
 
-export default connect(mapStateToProps)(ChallengeListApollo)
+export default connect(mapStateToProps)(HomeFeedContainerApollo)

--- a/src/components/tasks/TasksList.js
+++ b/src/components/tasks/TasksList.js
@@ -24,7 +24,7 @@ class TasksList extends Component {
   }
 
   renderDiscussionView = () =>{
-    const discussionId = this.props.state.openDiscusionId
+    const discussionId = this.props.openDiscusionId
     return(
       <Dialog
         title={'Discussion'}
@@ -59,7 +59,7 @@ class TasksList extends Component {
     return(
       <div>
         {this.renderTaskCards()}
-        {this.props.state.openDiscusionId && this.renderDiscussionView()}
+        {this.props.openDiscusionId && this.renderDiscussionView()}
       </div>
     )
   }
@@ -73,9 +73,7 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 const mapStateToProps = state => ({
-  state:{
     openDiscusionId: state.app.community.openDiscusionId,
-  }
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(TasksList)

--- a/src/lib/array-helpers.js
+++ b/src/lib/array-helpers.js
@@ -7,3 +7,24 @@ export const removeValueFromList = (value,list)=> {
     return [...list]
   }
 }
+
+/* normalizeToFeed takes an indefinite number of arrays and returns
+  1 list of all of the items in each of the arrays in the following shape:
+  [ array1[0],array2[0],array3[0],[array1[1],array2[1],array3[1], array1[2]... ]
+
+  example of use -->
+  const challenges:[<c>1</c>,<c>2</c>,<c>3</c>]
+  const tasks = [<t>1</c>,<t>2</c>]
+  normalizeToFeed(challenges,tasks)
+  > [<c>1</c>,<t>1</c>,<c>2</c>,<t>2</c>,<c>3</c>]
+*/
+export const normalizeToFeed = (...lists) => {
+  const listLengths = lists.map(list => list.length)
+  const longestListLength = Math.max(...listLengths)
+  const feed = []
+  for (let i = 0; i < longestListLength; i++){
+    lists.forEach(list => list[i] && feed.push(list[i]))
+  }; /* semi colon necessary here for loop to execute.
+  only use when using <= es5 features */
+  return feed
+}

--- a/src/lib/array-helpers.js
+++ b/src/lib/array-helpers.js
@@ -9,7 +9,7 @@ export const removeValueFromList = (value,list)=> {
 }
 
 /* normalizeToFeed takes an indefinite number of arrays and returns
-  1 list of all of the items in each of the arrays in the following shape:
+  1 list in the following order:
   [ array1[0],array2[0],array3[0],[array1[1],array2[1],array3[1], array1[2]... ]
 
   example of use -->
@@ -25,6 +25,6 @@ export const normalizeToFeed = (...lists) => {
   for (let i = 0; i < longestListLength; i++){
     lists.forEach(list => list[i] && feed.push(list[i]))
   }; /* semi colon necessary here for loop to execute.
-  only use when using <= es5 features */
+  only use for <= es5 features */
   return feed
 }

--- a/src/lib/array-helpers.test.js
+++ b/src/lib/array-helpers.test.js
@@ -1,6 +1,6 @@
-import {removeValueFromList} from './array-helpers'
+import {removeValueFromList, normalizeToFeed} from './array-helpers'
 
-test('removeValueFromList should remove given value from list', ()=>{
+test('removeValueFromList should remove given value from list', () => {
   const startList = [1,49,34,3]
   const value = 49
   const expected = [1,34,3]
@@ -8,7 +8,7 @@ test('removeValueFromList should remove given value from list', ()=>{
   expect(result).toEqual(expected)
 })
 
-test('removeValueFromList should not mutate the existing array', ()=>{
+test('removeValueFromList should not mutate the existing array', () => {
   const startList = [1,49,34,3]
   const value = 49
   const expected = [1,34,3]
@@ -16,10 +16,66 @@ test('removeValueFromList should not mutate the existing array', ()=>{
   expect(result).not.toBe(expected)
 })
 
-test('removeValueFromList returns existing list if value is not in list', ()=>{
+test('removeValueFromList returns existing list if value is not in list', () => {
   const startList = [1,49,34,3]
   const value = 50
   const expected = [1,49,34,3]
   const result = removeValueFromList(value, startList)
   expect(result).toEqual(expected)
+})
+
+/* ---------------------- normalizeToFeed ---------------------- */
+
+const feedData = {
+    challenges:[
+      "<Challenge>c-1</Challenge>",
+      "<Challenge>c-2</Challenge>",
+      "<Challenge>c-3</Challenge>",
+      "<Challenge>c-4</Challenge>",
+      "<Challenge>c-5</Challenge>"
+    ],
+    tasks:[
+      "<Task>t-1</Task>",
+      "<Task>t-2</Task>",
+      "<Task>t-3</Task>",
+      "<Task>t-4</Task>",
+    ],
+    actions: [
+      "<Action>t-1</Action>",
+      "<Action>t-2</Action>",
+      "<Action>t-3</Action>",
+    ]
+  }
+
+  const expectedFeedResult = [
+      "<Challenge>c-1</Challenge>",
+      "<Task>t-1</Task>",
+      "<Action>t-1</Action>",
+      "<Challenge>c-2</Challenge>",
+      "<Task>t-2</Task>",
+      "<Action>t-2</Action>",
+      "<Challenge>c-3</Challenge>",
+      "<Task>t-3</Task>",
+      "<Action>t-3</Action>",
+      "<Challenge>c-4</Challenge>",
+      "<Task>t-4</Task>",
+      "<Challenge>c-5</Challenge>"
+  ]
+
+test('normalizeToFeed should combine lists in expected shape', () => {
+  const feed = normalizeToFeed(
+    feedData.challenges,
+    feedData.tasks,
+    feedData.actions
+  )
+  expect(feed).toEqual(expectedFeedResult)
+})
+
+test('normalizeToFeed should combine lists in expected shape', () => {
+  const feed = normalizeToFeed(
+    feedData.challenges,
+    feedData.tasks,
+    feedData.actions
+  )
+  expect(feed).toEqual(expectedFeedResult)
 })

--- a/src/lib/array-helpers.test.js
+++ b/src/lib/array-helpers.test.js
@@ -71,7 +71,7 @@ test('normalizeToFeed should combine lists in expected shape', () => {
   expect(feed).toEqual(expectedFeedResult)
 })
 
-test('normalizeToFeed should combine lists in expected shape', () => {
+test('normalizeToFeed should combine lists in expected order', () => {
   const feed = normalizeToFeed(
     feedData.challenges,
     feedData.tasks,

--- a/src/ui-kit/index.js
+++ b/src/ui-kit/index.js
@@ -1,3 +1,4 @@
+export {default as Card} from './Card'
 export {default as Comment} from './Comment'
 export {default as TextButton} from './TextButton'
 export {default as InputWithProfile} from './InputWithProfile'


### PR DESCRIPTION
Creating a feed that accepts data from multiple different queries, and normalizes in 1 feed that has an order like: `[dataList1[0], dataList2,[0], dataList3[0], dataList1[1], dataList2,[1], dataList3[1]...]`,
This way can have a home feed that includes `<ChallengeCard />`'s,  and `<TaskCard/>`'s in alternating order.
## How

1. Have 1 parent data feed component that has multiple queries with their own refetch, and update methods.
2. Pass in data + data fetching functions to a feed component, create separate arrays of card elements for each data type, and normalize multiple arrays of elements into 1 composite feed array and render it.  Create 1 loadMore function that combines multiple loadMore methods, and is called when reach the end of the composite feed.
** Because all 3 queries are managed separately have a much easier way manipulating data in the Apollo store from other components in the app :)


example of apollo props for a feed container:
```
props:{
  allChallengesQuery{ loadMore, error, challenges:[]},
  allTasksQuery{ loadMore, error, tasks:[]},,
  allActionsQuery{ loadMore, error, actions:[]},
}
```
