### PR TITLE
Stop double render of community

### DIFF
--- a/src/components/BottomBar.js
+++ b/src/components/BottomBar.js
@@ -141,7 +141,7 @@ class BottomBar extends Component {
         docked={false}
         handleClose={this.handleCommunityClose}
         >
-        <Community/>
+          {this.props.isCommunityMobileOpen && <Community/> }
       </MuiDrawer>
     </div>
     )


### PR DESCRIPTION
Community was hidden but still rendering in drawer when it was not open 